### PR TITLE
Always zero encryption key on Stop

### DIFF
--- a/pkg/kek/kek.go
+++ b/pkg/kek/kek.go
@@ -47,7 +47,6 @@ func (c *cmdKEK) Get() ([]byte, error) {
 }
 
 func (c *cmdKEK) Stop() {
-	c.setErrorState(errEmptyKey)
 	close(c.stop)
 }
 
@@ -81,6 +80,7 @@ func (c *cmdKEK) run() {
 	const factor = 5 // TODO move constant, maybe make configurable?
 	ticker := time.NewTicker(c.duration / factor)
 	defer ticker.Stop()
+	defer c.setErrorState(errEmptyKey)
 
 	current := 0
 


### PR DESCRIPTION
This change moves the zero key on Stop logic into cmdKEK.run.  This
guarantees via a defer that it is the last thing executed when run
exits (and thus the key is always zeroed).

Signed-off-by: Monis Khan <mkhan@redhat.com>